### PR TITLE
fix(ci): unblock bot PRs and main verification

### DIFF
--- a/.github/workflows/git-hygiene.yml
+++ b/.github/workflows/git-hygiene.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   commitlint:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,6 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   branch-name:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/lockfile-rationale.yml
+++ b/.github/workflows/lockfile-rationale.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   enforce:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/git/guard-branch.sh
+++ b/scripts/git/guard-branch.sh
@@ -10,6 +10,11 @@ if [[ "$branch" == "HEAD" && ( "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "
   exit 0
 fi
 
+if [[ ( "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ) && ( "$branch" == "main" || "$branch" == "master" ) ]]; then
+  echo "Protected branch $branch allowed in CI."
+  exit 0
+fi
+
 if [[ "$branch" == "main" || "$branch" == "master" ]]; then
   echo "Direct work on $branch is blocked."
   exit 1


### PR DESCRIPTION
## What
- skip branch-name and commitlint jobs for automated dependency update branches
- skip lockfile rationale enforcement for automated dependency update branches
- allow protected branches through the branch guard when verification is running inside CI

## Why
- current Dependabot PRs are failing policy checks that are designed for human-authored branches and messages
- Nexus also has a `main` push verification failure because the branch guard blocks post-merge CI the same way it blocks direct local work on `main`

## How
- gate the workflow jobs on `dependabot/` and `renovate/` branch prefixes
- preserve the local protection against direct human work on `main` and `master`
- add a CI-only allowance for protected branches in `scripts/git/guard-branch.sh`

## Testing
- `git diff --check`
- `CI=true GITHUB_ACTIONS=true bash scripts/git/guard-branch.sh` with a mocked `main` branch returns success
- `bash scripts/git/guard-branch.sh` with a mocked `main` branch still fails outside CI

## Risk / Notes
- this is scoped to automated dependency branches and CI execution only
- local contributor workflows keep the existing branch restrictions
