### PR TITLE
fix(ci): quiet release workflow on main pushes

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -7,7 +7,15 @@ on:
       - "v*.*.*"
 
 jobs:
+  noop:
+    if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip release on non-tag push
+        run: echo "release-macos only packages tagged releases"
+
   release:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: macos-14
     permissions:
       contents: write


### PR DESCRIPTION
## What
- add a no-op success path for ordinary `main` pushes in `release-macos`
- keep the real macOS release job limited to tags and manual dispatch

## Why
- GitHub was recording failed release workflow runs on normal dependency merges even though no release should have happened

## How
- add a lightweight `noop` job for non-tag pushes
- gate the real `release` job behind tag or manual-dispatch conditions

## Testing
- `git diff --check`

## Risk / Notes
- normal pushes now show a successful no-op instead of a misleading failed release run
- tagged releases still use the existing macOS packaging path