### PR TITLE
fix(ci): keep release workflow green on branch pushes

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -3,10 +3,18 @@ name: release-macos
 on:
   workflow_dispatch:
   push:
+    branches: [main, master]
     tags:
       - "v*.*.*"
 
 jobs:
+  branch-push:
+    if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip release packaging
+        run: echo "release-macos packages only tagged or manually dispatched releases"
+
   release:
     if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: macos-14


### PR DESCRIPTION
## What
- Adds an explicit branch-push no-op job to release-macos.
- Keeps real macOS packaging restricted to tags or manual dispatch.

## Why
- The merge push still produced a failed release-macos run with no jobs.
- Main branch pushes need a green release workflow status instead of a failed empty run.

## How
- Includes main/master branch pushes in the workflow trigger.
- Runs a small skip job for branch pushes while leaving the release job gated to tags/manual runs.

## Testing
- pnpm exec prettier --check .github/workflows/release-macos.yml
- pnpm git:guard:all

## Performance Impact
- None; workflow-only change.

## Risk / Notes
- This will create a quick green release-macos run on main branch pushes.
- Tag and manual release behavior remains unchanged.

## Lockfile rationale
- N/A; no lockfile changed.

## Baseline governance
- N/A; no .perf-baselines changed.