### PR TITLE
fix(ci): always run release noop job

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   branch-push:
-    if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip release packaging


### PR DESCRIPTION
## What
- Makes the release-macos no-op job unconditional.
- Keeps actual release packaging gated to tag pushes or manual dispatch.

## Why
- Main branch pushes were still producing failed empty release-macos runs.
- The workflow needs at least one runnable job for branch pushes.

## How
- Leaves the branch-push no-op job always available.
- Keeps the release job guarded by tag/manual conditions.

## Testing
- pnpm exec prettier --check .github/workflows/release-macos.yml
- pnpm git:guard:all

## Performance Impact
- None; workflow-only change.

## Risk / Notes
- Tag/manual releases will also show the no-op job, alongside the real release job.

## Lockfile rationale
- N/A; no lockfile changed.

## Baseline governance
- N/A; no .perf-baselines changed.