### PR TITLE
fix(ci): set release key path at runtime

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -26,7 +26,6 @@ jobs:
       APPLE_SIGN_IDENTITY: ${{ secrets.APPLE_SIGN_IDENTITY }}
       APPLE_KEYCHAIN_PROFILE: ${{ secrets.APPLE_KEYCHAIN_PROFILE }}
       APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
-      APPLE_API_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
       APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
     steps:
@@ -47,7 +46,9 @@ jobs:
       - name: Prepare App Store Connect key
         if: ${{ env.RELEASE_NOTARIZE == '1' && env.APPLE_KEYCHAIN_PROFILE == '' && env.APPLE_API_KEY_P8_BASE64 != '' }}
         run: |
-          echo "$APPLE_API_KEY_P8_BASE64" | base64 --decode > "$APPLE_API_KEY_PATH"
+          key_path="$RUNNER_TEMP/AuthKey.p8"
+          echo "$APPLE_API_KEY_P8_BASE64" | base64 --decode > "$key_path"
+          echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
       - name: Release preflight
         run: pnpm release:mac:preflight


### PR DESCRIPTION
## What
- Moves the release notarization key path out of job-level env and sets it at runtime through GITHUB_ENV.
- Keeps the branch-push no-op job and tagged/manual release behavior intact.

## Why
- GitHub rejects runner.temp in job-level env before any release-macos job can start.

## How
- Uses RUNNER_TEMP inside the key preparation step, then exposes APPLE_API_KEY_PATH to later release steps.

## Testing
- pnpm exec prettier --check .github/workflows/release-macos.yml
- pnpm git:guard:all

## Performance Impact
- None expected.

## Risk / Notes
- Narrow workflow-only change. Notarized release paths should still fail preflight if required Apple credentials are missing.