### PR TITLE
ci: add CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '37 8 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## What
- Add a CodeQL workflow for the repo's supported language surfaces.
- Run on PRs, pushes to main, manual dispatch, and a weekly schedule.

## Why
- Security Review flagged this repo as missing CodeQL coverage.

## How
- Use the official CodeQL action with a minimal matrix: javascript-typescript.

## Testing
- Not run locally (GitHub Actions workflow-only change).

## Performance Impact
- Adds CI runtime only when the workflow is triggered.

## Risk / Notes
- Config-only change; Rust code is intentionally not included because CodeQL does not support Rust analysis.